### PR TITLE
Command to update cryptobib via pull

### DIFF
--- a/citerus/citerus.py
+++ b/citerus/citerus.py
@@ -180,6 +180,7 @@ def argparse_setup():
     group_adm = parser.add_argument_group('Other arguments')
     group_adm.add_argument('--cleanup', action='store_true', dest='cleanup', help="Cleanup DB files (reset cryptobib and index)")
     group_adm.add_argument('--cleandb', action='store_true', dest='cleandb', help="Reset DB index")
+    group_adm.add_argument('--updatedb', action='store_true', dest='updatedb', help="Update cryptobib")
     group_adm.add_argument('--logo', action='store_true', dest='logo_help', help="Print logo together with help")
 
 
@@ -204,6 +205,12 @@ def main():
     if args.cleandb:
         cryptodbreader.cleandb()
         sys.exit(0)
+
+    if args.updatedb:
+        cryptodbreader.update_cryptobib()
+        cryptodbreader.cleandb()
+        sys.exit(0)
+
     if args.logo_help:
         citeruslogo.print_logo()
         print()

--- a/citerus/citerus.py
+++ b/citerus/citerus.py
@@ -179,6 +179,7 @@ def argparse_setup():
 
     group_adm = parser.add_argument_group('Other arguments')
     group_adm.add_argument('--cleanup', action='store_true', dest='cleanup', help="Cleanup DB files (reset cryptobib and index)")
+    group_adm.add_argument('--cleandb', action='store_true', dest='cleandb', help="Reset DB index")
     group_adm.add_argument('--logo', action='store_true', dest='logo_help', help="Print logo together with help")
 
 
@@ -200,6 +201,9 @@ def main():
         cryptodbreader.cleanup()
         sys.exit(0)
 
+    if args.cleandb:
+        cryptodbreader.cleandb()
+        sys.exit(0)
     if args.logo_help:
         citeruslogo.print_logo()
         print()

--- a/citerus/cryptodbreader.py
+++ b/citerus/cryptodbreader.py
@@ -33,6 +33,13 @@ def cleanup():
         #print("Error: %s - %s." % (e.filename, e.strerror))
         pass # Silent (redundant cleanups do not need to be announced)
 
+def cleandb():
+    try:
+        os.remove(path_citme_db)
+    except FileNotFoundError as e:
+        #print("Error: %s - %s." % (e.filename, e.strerror))
+        pass # Silent (redundant cleanups do not need to be announced)
+
 def search_bib(db, args):
     titles = args.t
     authors = args.a

--- a/citerus/cryptodbreader.py
+++ b/citerus/cryptodbreader.py
@@ -106,6 +106,18 @@ def ensure_cryptodb_exists(file_path):
     git.Repo.clone_from('https://github.com/cryptobib/export.git', CRYPTOBIB_ROOT, branch='master', progress=CloneProgress())
     print()
 
+def update_cryptobib():
+    print('Pulling cryptobib (this may take a few seconds)...')
+    try:
+        repo = git.Repo(CRYPTOBIB_ROOT)
+    except (git.InvalidGitRepositoryError, git.NoSuchPathError) as e:
+        print("Error: %s - %s." % (e.filename, e.strerror))
+        print("Run `citerus --cleanup`")
+        sys.exit(1)
+    
+    repo.remote().pull(progress=CloneProgress())
+
+    print()
 
 def parse_cryptodb(file_path):
     citeruslogo.print_logo()


### PR DESCRIPTION
Currently, to update cryptobib, it is necessary to use the `--cleanup` option, which deletes the folder and clones the repository again. Since cryptobib is quite large, I think it is easier to do a pull when you want to update it.

I added the `--updatedb` option which pulls and cleans the db, this way the index is automatically rebuilt at the next run. This should partially resolve #4.

I also added the `--cleandb` option to force the index rebuild (this can be useful if you manually edit the cryptobib repository).